### PR TITLE
Service values may be null

### DIFF
--- a/src/CfCommunity/CfHelper/Services/Service.php
+++ b/src/CfCommunity/CfHelper/Services/Service.php
@@ -36,15 +36,15 @@ class Service
     private $tags;
 
     /**
-     * @param $name
-     * @param array $values
-     * @param null $label
-     * @param array $tags
+     * @param string $name
+     * @param array|null $values
+     * @param string|null $label
+     * @param array|null $tags
      */
-    function __construct($name, array $values, $label = null, $tags = array())
+    function __construct($name, array $values = null, $label = null, $tags = array())
     {
         $this->name = $name;
-        $this->values = $values;
+        $this->values = $values ? $values : array();
         $this->label = $label;
         $this->tags = $tags;
     }
@@ -76,7 +76,7 @@ class Service
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getName()
     {
@@ -84,7 +84,7 @@ class Service
     }
 
     /**
-     * @param mixed $name
+     * @param string $name
      */
     public function setName($name)
     {


### PR DESCRIPTION
`$serviceManager->getAllServices()` fails if a service has `null` value for `credentials` because of:

```php
private function makeService($service)
    {
        $serviceObject = new Service($service['name'], $service['credentials'], $service['label'], $service['tags']);
```