### PR TITLE
Fixed issues when detecting connector

### DIFF
--- a/src/CfCommunity/CfHelper/CfHelper.php
+++ b/src/CfCommunity/CfHelper/CfHelper.php
@@ -130,11 +130,11 @@ class CfHelper
         if (substr($methodName, 0, 3) !== 'get') {
             throw new \Exception('Method ' . $methodName . ' not exists');
         }
-        if (substr($methodName, -strlen("Connector")) !== "Connector") {
+        $strSize = strlen("Connector");
+        if (substr($methodName, -$strSize) !== "Connector") {
             throw new \Exception('Method ' . $methodName . ' not exists');
         }
-        $connectorName = substr($methodName, 3);
-        $connectorName = substr_replace($connectorName, "Connector", 0);
+        $connectorName = strtolower(substr($methodName, 3, $strSize - 1));
 
         $connector = $this->getConnector($connectorName);
         if (isset($this->connectorsState[$connector->getName()])) {


### PR DESCRIPTION
When detecting the connector, it is returning the connector string instead of the database type, such as MongoDB, MySQL, or PostgreSQL

```
        $connectorName = substr_replace($connectorName, "Connector", 0);
```

The one above is returning the value of "Connector."

Could you please approve this pull request? It is currently blocking the use of this library.
